### PR TITLE
fix building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Use glob syntax:
-syntax: glob
-
 # The local makefile should be ignored:
 Makefile.local
 Makefile.fordist
@@ -45,7 +42,3 @@ ogfx-trains.nml
 
 # Ignore nml cache:
 .nmlcache
-
-# Ignore source directory cloned from ogfx-train-renders
-syntax: regexp
-^sprite_source/blender

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ GIT            ?= git
 PYTHON         ?= python
 
 UNIX2DOS       ?= unix2dos
-UNIX2DOS_FLAGS ?= $(shell [ -n $(UNIX2DOS) ] && $(UNIX2DOS) -q --version 2>/dev/null && echo "-q" || echo "")
+UNIX2DOS_FLAGS ?= $(shell [ -n $(UNIX2DOS) ] && $(UNIX2DOS) -q --version 2>/dev/null 1>&2 && echo "-q" || echo "")
 
 ################################################################
 # Get the Repository revision, tags and the modified status
@@ -395,7 +395,7 @@ bananas: $(DIR_NAME)
 
 $(DIR_NAME).tar: $(DIR_NAME)
 	$(_E) "[BUNDLE TAR] $@"
-	$(_V) $(TAR) $(TAR_FLAGS) $@ $< --exclude=bananas.ini
+	$(_V) $(TAR) --exclude=bananas.ini $(TAR_FLAGS) $@ $<
 
 bundle_tar: $(DIR_NAME).tar
 bundle_zip: $(ZIP_FILENAME)


### PR DESCRIPTION
at some point it seems the correct order of flags for `tar` was changed, and the `-q` flag for `unix2dos` broken.
this patch:

- rearranges the order of flags given to `tar`
- redirects all output to `dev/null` when testing for `unix2dos`, not just `stderr`
- adds a `.gitignore` to prevent built files from interfering with git